### PR TITLE
libcontainer/configs: fix unit tests

### DIFF
--- a/libcontainer/configs/config_test.go
+++ b/libcontainer/configs/config_test.go
@@ -160,7 +160,7 @@ func TestCommandHookRun(t *testing.T) {
 		Pid:     1,
 		Bundle:  "/bundle",
 	}
-	timeout := time.Second
+	timeout := 10 * time.Second
 
 	cmdHook := configs.NewCommandHook(configs.Command{
 		Path:    os.Args[0],
@@ -184,7 +184,7 @@ func TestCommandHookRunTimeout(t *testing.T) {
 		Pid:     1,
 		Bundle:  "/bundle",
 	}
-	timeout := (10 * time.Millisecond)
+	timeout := 10 * time.Millisecond
 
 	cmdHook := configs.NewCommandHook(configs.Command{
 		Path:    os.Args[0],
@@ -202,7 +202,6 @@ func TestCommandHookRunTimeout(t *testing.T) {
 
 func TestHelperProcess(*testing.T) {
 	fmt.Println("Helper Process")
-	os.Exit(0)
 }
 func TestHelperProcessWithTimeout(*testing.T) {
 	time.Sleep(time.Second)


### PR DESCRIPTION
The 'TestHelperProcess' function is used by 'TestCommandHookRun' by running
'go -test.run=TestHelperProcess' as a hook command in a different process.
This function is also run in the main test process, making it to exit with 0
even if there are tests failing.

This commit removes the 'os.Exit(0)' call and increases the timeout to 10
seconds as it was too low and the test was failing.

Signed-off-by: Mauricio Vásquez <mauricio@kinvolk.io>

----

@alban could you please check if it makes sense to open it upstream before the seccomphook work?